### PR TITLE
Use a local pip installable module for custom environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
 venv/
-.DS_Store
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/custom_minigrid_envs/__init__.py
+++ b/custom_minigrid_envs/__init__.py
@@ -1,0 +1,6 @@
+from gymnasium.envs.registration import register
+
+register(
+    id='MiniGrid-Custom-TestEnv',
+    entry_point='custom_minigrid_envs.envs:TestEnv',
+)

--- a/custom_minigrid_envs/envs/__init__.py
+++ b/custom_minigrid_envs/envs/__init__.py
@@ -1,0 +1,1 @@
+from custom_minigrid_envs.envs.testenv import TestEnv

--- a/custom_minigrid_envs/envs/testenv.py
+++ b/custom_minigrid_envs/envs/testenv.py
@@ -1,0 +1,146 @@
+from typing import Optional
+
+from minigrid.core.grid import Grid
+from minigrid.core.mission import MissionSpace
+from minigrid.core.world_object import Goal
+from minigrid.minigrid_env import MiniGridEnv
+from minigrid.core.world_object import Wall, WorldObj
+import numpy as np
+import imageio
+
+
+class TestEnv(MiniGridEnv):
+    """
+    <p>
+        <img src="https://raw.githubusercontent.com/Farama-Foundation/Minigrid/master/figures/empty-env.png" alt="dempty-env" width="200px"/>
+    </p>
+
+    ### Description
+
+    This environment is an empty room, and the goal of the agent is to reach the
+    green goal square, which provides a sparse reward. A small penalty is
+    subtracted for the number of steps to reach the goal. This environment is
+    useful, with small rooms, to validate that your RL algorithm works
+    correctly, and with large rooms to experiment with sparse rewards and
+    exploration. The random variants of the environment have the agent starting
+    at a random position for each episode, while the regular variants have the
+    agent always starting in the corner opposite to the goal.
+
+    ### Mission Space
+
+    "get to the green goal square"
+
+    ### Action Space
+
+    | Num | Name         | Action       |
+    |-----|--------------|--------------|
+    | 0   | left         | Turn left    |
+    | 1   | right        | Turn right   |
+    | 2   | forward      | Move forward |
+    | 3   | pickup       | Unused       |
+    | 4   | drop         | Unused       |
+    | 5   | toggle       | Unused       |
+    | 6   | done         | Unused       |
+
+    ### Observation Encoding
+
+    - Each tile is encoded as a 3 dimensional tuple:
+        `(OBJECT_IDX, COLOR_IDX, STATE)`
+    - `OBJECT_TO_IDX` and `COLOR_TO_IDX` mapping can be found in
+        [minigrid/minigrid.py](minigrid/minigrid.py)
+    - `STATE` refers to the door state with 0=open, 1=closed and 2=locked
+
+    ### Rewards
+
+    A reward of '1' is given for success, and '0' for failure.
+
+    ### Termination
+
+    The episode ends if any one of the following conditions is met:
+
+    1. The agent reaches the goal.
+    2. Timeout (see `max_steps`).
+
+    ### Registered Configurations
+
+    - `MiniGrid-Empty-5x5-v0`
+    - `MiniGrid-Empty-Random-5x5-v0`
+    - `MiniGrid-Empty-6x6-v0`
+    - `MiniGrid-Empty-Random-6x6-v0`
+    - `MiniGrid-Empty-8x8-v0`
+    - `MiniGrid-Empty-16x16-v0`
+
+    """
+
+    def __init__(
+        self,
+        agent_start_pos=(1, 1),
+        agent_start_dir=0,
+        max_steps: Optional[int] = None,
+        **kwargs
+    ):
+    
+        im = imageio.imread('env1.png')
+        width = len(im[0])
+        height = len(im)
+        self.agent_start_pos = agent_start_pos
+        self.agent_start_dir = agent_start_dir
+
+        mission_space = MissionSpace(mission_func=self._gen_mission)
+
+
+        max_steps = 4 * width**2
+
+        super().__init__(
+            mission_space=mission_space,
+            width=width,
+            height=height,
+            # Set this to True for maximum speed
+            see_through_walls=True,
+            max_steps=max_steps,
+            **kwargs
+        )
+
+    @staticmethod
+    def _gen_mission():
+        return "get to the green goal square"
+
+    def _gen_grid(self, width, height):
+        # Create an empty grid
+        im = imageio.imread('env1.png')
+
+        self.grid = Grid(width, height)
+        obj_type = Wall
+        
+        hasGoal = False
+        hasStart = False
+        
+        
+        # Generate the surrounding walls
+        for x in range(0,width):
+            for y in range(0,height):
+                if np.sum(im[y][x]) == 255:
+                    self.grid.set(x, y, obj_type())
+                #goal 101 - 254
+                if np.sum(im[y][x]) > 255 and np.sum(im[y][x]) < 510:
+                    self.put_obj(Goal(), x, y)    
+                    hasGoal = True
+                #start 1 - 100
+                if np.sum(im[y][x]) > 511 and np.sum(im[y][x]) < 1020:
+                    print("set start pos")
+                    self.agent_start_pos = (x,y)
+                    hasStart = True
+
+
+        # Place a goal square in the bottom-right corner
+        if hasGoal is False:
+            self.put_obj(Goal(), width - 2, height - 2)
+
+        # Place the agent
+        if self.agent_start_pos is not None:
+            self.agent_pos = self.agent_start_pos
+            self.agent_dir = self.agent_start_dir
+        else:
+            self.place_agent()
+
+        self.mission = "get to the green goal square"

--- a/custom_minigrid_envs/setup.py
+++ b/custom_minigrid_envs/setup.py
@@ -1,0 +1,8 @@
+from gettext import install
+from setuptools import setup
+
+setup(
+    name="custom_minigrid_envs",
+    version="0.0.1",
+    install_requires=["gymnasium", "minigrid"]
+)

--- a/demo_live.py
+++ b/demo_live.py
@@ -53,4 +53,6 @@ if graph.n_communities is not None:
     plt.title('ground truth clusters')
     plt.subplot(1, n_panels, 3)
     graph.plot(node_colors={graph.nodes[i]: colors[graph.communities[i]] for i in range(graph.n_nodes)})
-plt.pause(10)
+
+plt.ioff()
+plt.show()

--- a/hippocluster/graphs/environment.py
+++ b/hippocluster/graphs/environment.py
@@ -7,6 +7,7 @@ import networkx as nx
 import matplotlib.pyplot as plt
 import gymnasium as gym
 import minigrid
+import custom_minigrid_envs
 
 def make_env(env_key, seed=None, render_mode=None):
 	env = gym.make(env_key, render_mode=render_mode)

--- a/hippocluster/graphs/environment.py
+++ b/hippocluster/graphs/environment.py
@@ -62,7 +62,7 @@ class RandomWalkEnvironment(RandomWalkGraph):
 		for i in range(len(edges)):
 			add_edge_to_graph(G, points[edges[i][0]], points[edges[i][1]], edges[i][2])
 
-		super().__init__(G, pos={node: list(node) for node in G.nodes})
+		super().__init__(G, pos={node: (node[0], node[1]*-1) for node in G.nodes})
 
 	@property
 	def communities(self):


### PR DESCRIPTION
### What's happening in this PR?
This PR introduces a pip installable `custom_minigrid_envs` module that allows you to register as many custom environments as you would like. This should *replace* the need for a fork of the Minigrid repo. To create this environment setup I followed the gym documentation [here](https://www.gymlibrary.dev/content/environment_creation/). 

`testenv.py` contains the Minigrid gym environment while the `setup.py` file is the one that registers the environment. 

### How do I test it myself?
1. Clone the repository and cd into it.
```
git clone https://github.com/echalmers/env2graph.git
cd env2graph
``` 
2. Checkout this branch
```
git checkout custom-environments
```
3. Run the following command to set up the `custom_minigrid_envs` custom environment as well as any dependencies.
**NOTE: You need to do this every time you close/re-open your terminal. The python virtual environment is temporary only for your current terminal session.**
```
cd custom_minigrid_envs && python3 -m venv .env && source .env/bin/activate && pip3 install -e . && pip3 install -r ../requirements.txt && cd ..
```
4. Try it out!
```
python3 demo_live.py
```

### NOTE:
These instructions are for Mac, so you *may* need to use `python` rather than `python3` if you're on windows. 